### PR TITLE
Skip empty lines when indenting blocks

### DIFF
--- a/aggressive-indent.el
+++ b/aggressive-indent.el
@@ -263,7 +263,7 @@ until nothing more happens."
       (indent-according-to-mode))
     ;; And then we indent each following line until nothing happens.
     (forward-line 1)
-    (while (/= (progn (skip-chars-forward "[:blank:]")
+    (while (/= (progn (skip-chars-forward "[:blank:]\n")
                       (point))
                (progn (indent-according-to-mode)
                       (point)))


### PR DESCRIPTION
A fix to prevent adding indentation spaces to empty lines.
