### PR TITLE
Don't indent inside comments, but allow as an option.

### DIFF
--- a/aggressive-indent.el
+++ b/aggressive-indent.el
@@ -123,12 +123,18 @@ commands will NOT be followed by a re-indent."
   :type '(repeat symbol)
   :package-version '(aggressive-indent . "0.1"))
 
+(defcustom comments-too nil
+  "If non-nil, aggressively indent in comments as well."
+  :type 'boolean)
+
 (defvar -internal-dont-indent-if
   '((memq this-command aggressive-indent-protected-commands)
     (region-active-p)
     buffer-read-only
     (null (buffer-modified-p))
-    (string-match "\\`[[:blank:]]*\n?\\'" (thing-at-point 'line)))
+    (string-match "\\`[[:blank:]]*\n?\\'" (thing-at-point 'line))
+    (and (aggressive-indent--in-comment-p)
+         (not aggressive-indent-comments-too)))
   "List of forms which prevent indentation when they evaluate to non-nil.
 This is for internal use only. For user customization, use
 `aggressive-indent-dont-indent-if' instead.")
@@ -302,6 +308,11 @@ Like `aggressive-indent-indent-region-and-on', but wrapped in a
   "Store the limits of each change that happens in the buffer."
   (push l changed-list-left)
   (push r changed-list-right))
+
+(defun -in-comment-p ()
+  "Return non-nil if point is inside a comment.
+Assumes that the syntax table is sufficient to find comments."
+  (nth 4 (syntax-ppss)))
 
 
 ;;; Minor modes


### PR DESCRIPTION
See issue #15.

This mostly works, but it falls in one corner-case:

```
;|
```

press enter:

```
                                        ;
|
```

It's not clear to me which code makes aggressive-indent modify the current line. Is this a bug in how `-internal-dont-indent-if` works?

---

A few thoughts on names.el, if it's helpful to you:

The approach works well, and I found the rules easy to grok (names are replaced except in quoted sections).

I managed to hack on the code, but it was harder than usual. Once I found `names-eval-defun` matters improved considerably. I think names-dev.el should autoload its functions, as they're less discoverable otherwise.

Still, a lot of my usual elisp tooling doesn't work. I can't use elisp-slime-nav to jump to a definition. I can't use highlight-symbol-next to jump between definition and usage of a variable or function.

There's a weird effect with `M-:`. If I press TAB I get the message:

```
[names] No :package given. Guessing `aggressive-indent'
```

However, this is just a message from tab-completion. `M-:` doesn't understand the current namespace. Perhaps it should. Either way, I think chatty tab completion is confusing.

Hope that's useful.
