### PR TITLE
Add diff-mode and makefile-mode to excluded-modes.

### DIFF
--- a/aggressive-indent.el
+++ b/aggressive-indent.el
@@ -134,9 +134,11 @@ Please include this in your report!"
   '(
     bibtex-mode
     coffee-mode
+    diff-mode
     erc-mode
     jabber-chat-mode
     haml-mode
+    makefile-mode
     minibuffer-inactive-mode
     python-mode
     special-mode


### PR DESCRIPTION
Well, those two modes (or their file formats) are very sensitive to whitespaces, so they should be excluded from aggressive indentation.
