### PR TITLE
Prevent that to replace the 'message' func to 'ignore' func.

### DIFF
--- a/aggressive-indent.el
+++ b/aggressive-indent.el
@@ -104,9 +104,8 @@ Meant for use in functions which go in hooks."
                 'aggressive-indent--internal-dont-indent-if
                 #'eval)
                (aggressive-indent--run-user-hooks))
-     (ignore-errors
-       (cl-letf (((symbol-function 'message) #'ignore))
-         ,@body))))
+     (cl-letf (((symbol-function 'message) #'ignore))
+       (ignore-errors ,@body))))
 
 ;;;###autoload
 (define-namespace aggressive-indent- :group indent
@@ -259,9 +258,8 @@ Like `aggressive-indent-indent-defun', but wrapped in a
                'aggressive-indent--internal-dont-indent-if
                #'eval)
               (aggressive-indent--run-user-hooks))
-    (ignore-errors
-      (cl-letf (((symbol-function 'message) #'ignore))
-        (indent-defun)))))
+    (cl-letf (((symbol-function 'message) #'ignore))
+      (ignore-errors (indent-defun)))))
 
 :autoload
 (defun indent-region-and-on (l r)
@@ -305,9 +303,8 @@ Like `aggressive-indent-indent-region-and-on', but wrapped in a
                'aggressive-indent--internal-dont-indent-if
                #'eval)
               (aggressive-indent--run-user-hooks))
-    (ignore-errors
-      (cl-letf (((symbol-function 'message) #'ignore))
-        (indent-region-and-on l r)))))
+    (cl-letf (((symbol-function 'message) #'ignore))
+      (ignore-errors (indent-region-and-on l r)))))
 
 (defvar -changed-list-right nil
   "List of right limit of regions changed in the last command loop.")


### PR DESCRIPTION
My English is poor, but I hope you can understand me.

——————

In the cider-repl mode, I encounter a problem that replaced the `message` function to `ignore` function.
I was found a reproduce pass:
1. (add-hook 'cider-repl-mode-hook 'aggressive-indent-mode)
2. (cider-connect ...)
3. (message "tell me something") ;; in the "_scratch_" buffer.

Beginning of the problem is `cl-letf` macro.
`cl-letf` macro is using `unwind-protect` function to restore changed name of functions. But `unwind-protect` function won't evaluate a restore section(= unwind-forms) when `lisp-nesting-exceeds` error occurred.

——————

``` elisp
; You can see the bug(or intended feature) of 'unwind-protect' using the following code.
(defun endless-recursive ()
  (endless-recursive))

(unwind-protect
    (endless-recursive)
  (message "finally"))
```

——————

``` elisp
(defvar save-message-func (symbol-function 'message))
(fset 'message save-message-func)

; Your code will be executed as code such as the following.
(with-current-buffer (get-buffer "*cider-repl impl*")
  (ignore-errors (print (symbol-function 'message))
                 (cl-letf (((symbol-function 'message) #'ignore))
                   (indent-region (point-min) (point-max)))
                 (print (symbol-function 'message))))
```
