### PR TITLE
Add more excluded modes

### DIFF
--- a/aggressive-indent.el
+++ b/aggressive-indent.el
@@ -138,11 +138,13 @@ Please include this in your report!"
     erc-mode
     jabber-chat-mode
     haml-mode
+    haskell-mode
     makefile-mode
     minibuffer-inactive-mode
     python-mode
     special-mode
     shell-mode
+    snippet-mode
     eshell-mode
     tabulated-list-mode
     term-mode


### PR DESCRIPTION
`haskell-mode` for similar reasons to python.

`snippet-mode` (which is for editing yas snippets) because there is no "correct" way to indent a
snippet which could be in any language.
