### PR TITLE
Exclude sass-mode and slim-mode

### DIFF
--- a/aggressive-indent.el
+++ b/aggressive-indent.el
@@ -142,6 +142,8 @@ Please include this in your report!"
     makefile-mode
     minibuffer-inactive-mode
     python-mode
+    sass-mode
+    slim-mode
     special-mode
     shell-mode
     snippet-mode


### PR DESCRIPTION
If haml-mode is excluded, sass-mode and slim-mode should be too.
