### PR TITLE
replace control characters with call to `kbd'

### DIFF
--- a/aggressive-indent.el
+++ b/aggressive-indent.el
@@ -381,7 +381,7 @@ or messages."
 ;;;###autoload
 (define-minor-mode aggressive-indent-mode
   nil nil " =>"
-  '(("" . aggressive-indent-indent-defun)
+  '(((kbd "C-c C-q") . aggressive-indent-indent-defun)
     ([backspace]
      menu-item "maybe-delete-indentation" ignore :filter
      (lambda (&optional _)

--- a/aggressive-indent.el
+++ b/aggressive-indent.el
@@ -382,15 +382,15 @@ or messages."
 (define-minor-mode aggressive-indent-mode
   nil nil " =>"
   `((,(kbd "C-c C-q") . aggressive-indent-indent-defun)
-   ([backspace]
-    menu-item "maybe-delete-indentation" ignore :filter
-    (lambda (&optional _)
-      (when (and (looking-back "^[[:blank:]]+")
-                 ;; Wherever we don't want to indent, we probably also
-                 ;; want the default backspace behavior.
-                 (not (run-hook-wrapped 'aggressive-indent--internal-dont-indent-if #'eval))
-                 (not (aggressive-indent--run-user-hooks)))
-        #'delete-indentation))))
+    ([backspace]
+     menu-item "maybe-delete-indentation" ignore :filter
+     (lambda (&optional _)
+       (when (and (looking-back "^[[:blank:]]+")
+                  ;; Wherever we don't want to indent, we probably also
+                  ;; want the default backspace behavior.
+                  (not (run-hook-wrapped 'aggressive-indent--internal-dont-indent-if #'eval))
+                  (not (aggressive-indent--run-user-hooks)))
+         #'delete-indentation))))
   (if aggressive-indent-mode
       (if (and global-aggressive-indent-mode
                (or (cl-member-if #'derived-mode-p aggressive-indent-excluded-modes)

--- a/aggressive-indent.el
+++ b/aggressive-indent.el
@@ -381,16 +381,16 @@ or messages."
 ;;;###autoload
 (define-minor-mode aggressive-indent-mode
   nil nil " =>"
-  '(((kbd "C-c C-q") . aggressive-indent-indent-defun)
-    ([backspace]
-     menu-item "maybe-delete-indentation" ignore :filter
-     (lambda (&optional _)
-       (when (and (looking-back "^[[:blank:]]+")
-                  ;; Wherever we don't want to indent, we probably also
-                  ;; want the default backspace behavior.
-                  (not (run-hook-wrapped 'aggressive-indent--internal-dont-indent-if #'eval))
-                  (not (aggressive-indent--run-user-hooks)))
-         #'delete-indentation))))
+  `((,(kbd "C-c C-q") . aggressive-indent-indent-defun)
+   ([backspace]
+    menu-item "maybe-delete-indentation" ignore :filter
+    (lambda (&optional _)
+      (when (and (looking-back "^[[:blank:]]+")
+                 ;; Wherever we don't want to indent, we probably also
+                 ;; want the default backspace behavior.
+                 (not (run-hook-wrapped 'aggressive-indent--internal-dont-indent-if #'eval))
+                 (not (aggressive-indent--run-user-hooks)))
+        #'delete-indentation))))
   (if aggressive-indent-mode
       (if (and global-aggressive-indent-mode
                (or (cl-member-if #'derived-mode-p aggressive-indent-excluded-modes)


### PR DESCRIPTION
Control characters embedded in the elisp file confuses tools like
file(1) (and thus Debian packaging tools).

Pre-patch:

    % file aggressive-indent.el
    aggressive-indent.el: data

Post-patch:

    % file aggressive-indent.el
    aggressive-indent.el: Lisp/Scheme program, ASCII text

Closes #64.