### PR TITLE
Check no-indent conditions at lower level, so they work on save

### DIFF
--- a/aggressive-indent.el
+++ b/aggressive-indent.el
@@ -389,20 +389,22 @@ or messages."
 
 (defun aggressive-indent--proccess-changed-list-and-indent ()
   "Indent the regions in `aggressive-indent--changed-list'."
-  (let ((inhibit-modification-hooks t)
-        (inhibit-point-motion-hooks t)
-        (indent-function
-         (if (cl-member-if #'derived-mode-p aggressive-indent-modes-to-prefer-defun)
-             #'aggressive-indent--softly-indent-defun #'aggressive-indent--softly-indent-region-and-on)))
-    ;; Take the 10 most recent changes.
-    (let ((cell (nthcdr 10 aggressive-indent--changed-list)))
-      (when cell (setcdr cell nil)))
-    ;; (message "----------")
-    (while aggressive-indent--changed-list
-      ;; (message "%S" (car aggressive-indent--changed-list))
-      (apply indent-function (car aggressive-indent--changed-list))
-      (setq aggressive-indent--changed-list
-            (cdr aggressive-indent--changed-list)))))
+  (unless (or (run-hook-wrapped 'aggressive-indent--internal-dont-indent-if #'eval)
+              (aggressive-indent--run-user-hooks))
+    (let ((inhibit-modification-hooks t)
+          (inhibit-point-motion-hooks t)
+          (indent-function
+           (if (cl-member-if #'derived-mode-p aggressive-indent-modes-to-prefer-defun)
+               #'aggressive-indent--softly-indent-defun #'aggressive-indent--softly-indent-region-and-on)))
+      ;; Take the 10 most recent changes.
+      (let ((cell (nthcdr 10 aggressive-indent--changed-list)))
+        (when cell (setcdr cell nil)))
+      ;; (message "----------")
+      (while aggressive-indent--changed-list
+        ;; (message "%S" (car aggressive-indent--changed-list))
+        (apply indent-function (car aggressive-indent--changed-list))
+        (setq aggressive-indent--changed-list
+              (cdr aggressive-indent--changed-list))))))
 
 (defcustom aggressive-indent-sit-for-time 0.05
   "Time, in seconds, to wait before indenting.
@@ -418,10 +420,8 @@ typing, try tweaking this number."
   (when (and aggressive-indent-mode aggressive-indent--changed-list)
     (save-excursion
       (save-selected-window
-        (unless (or (run-hook-wrapped 'aggressive-indent--internal-dont-indent-if #'eval)
-                    (aggressive-indent--run-user-hooks))
-          (while-no-input
-            (aggressive-indent--proccess-changed-list-and-indent)))))
+        (while-no-input
+          (aggressive-indent--proccess-changed-list-and-indent))))
     (when (timerp aggressive-indent--idle-timer)
       (cancel-timer aggressive-indent--idle-timer))))
 


### PR DESCRIPTION
Otherwise, things like `smerge-mode` indent protection are for nothing
when the user saves the buffer (which can be quite often during a big
merge).

* aggressive-indent.el
(aggressive-indent--proccess-changed-list-and-indent): Check
aggressive-indent--internal-dont-indent-if here.
(aggressive-indent--indent-if-changed): Not here.