### PR TITLE
Revert "Make the idle timer not be buffer local"

### DIFF
--- a/aggressive-indent.el
+++ b/aggressive-indent.el
@@ -412,7 +412,7 @@ If you feel aggressive-indent is causing Emacs to hang while
 typing, try tweaking this number."
   :type 'float)
 
-(defvar aggressive-indent--idle-timer nil
+(defvar-local aggressive-indent--idle-timer nil
   "Idle timer used for indentation")
 
 (defun aggressive-indent--indent-if-changed ()
@@ -421,15 +421,18 @@ typing, try tweaking this number."
     (save-excursion
       (save-selected-window
         (while-no-input
-          (aggressive-indent--proccess-changed-list-and-indent))))))
+          (aggressive-indent--proccess-changed-list-and-indent))))
+    (when (timerp aggressive-indent--idle-timer)
+      (cancel-timer aggressive-indent--idle-timer))))
 
 (defun aggressive-indent--keep-track-of-changes (l r &rest _)
   "Store the limits (L and R) of each change in the buffer."
   (when aggressive-indent-mode
     (push (list l r) aggressive-indent--changed-list)
-    (unless (timerp aggressive-indent--idle-timer)
-      (setq aggressive-indent--idle-timer
-            (run-with-idle-timer aggressive-indent-sit-for-time t #'aggressive-indent--indent-if-changed)))))
+    (when (timerp aggressive-indent--idle-timer)
+      (cancel-timer aggressive-indent--idle-timer))
+    (setq aggressive-indent--idle-timer
+          (run-with-idle-timer aggressive-indent-sit-for-time t #'aggressive-indent--indent-if-changed))))
 
 ;;; Minor modes
 ;;;###autoload
@@ -462,8 +465,7 @@ typing, try tweaking this number."
         (add-hook 'before-save-hook #'aggressive-indent--proccess-changed-list-and-indent nil 'local))
     ;; Clean the hooks
     (when (timerp aggressive-indent--idle-timer)
-      (cancel-timer aggressive-indent--idle-timer)
-      (setq aggressive-indent--idle-timer nil))
+      (cancel-timer aggressive-indent--idle-timer))
     (remove-hook 'after-change-functions #'aggressive-indent--keep-track-of-changes 'local)
     (remove-hook 'before-save-hook #'aggressive-indent--proccess-changed-list-and-indent 'local)
     (remove-hook 'post-command-hook #'aggressive-indent--softly-indent-defun 'local)))


### PR DESCRIPTION
This reverts commit cc8da01e32684e1b75d2901400e6723b2c2d42f8.

Since this commit, interaction with `flymake-mode` in `.el` buffers (and probably some other modes) is broken.

To reproduce:

```
emacs -Q -l aggressive-indent.el -f global-aggressive-indent-mode aggressive-indent.el -f flymake.mode ;; use the aggressive-indent.el file itself as a test fixture
C-s s t r i n g p ;; search forward to an appropriate sexp (should land you around line 176)
C-M-u ;; to go to the beginning of this sexp
C-M ;; newline
```
The form is not indented as desired.

If I revert the commit, everything is OK.
