### PR TITLE
Fixes missing timer error

### DIFF
--- a/aggressive-indent.el
+++ b/aggressive-indent.el
@@ -462,7 +462,8 @@ If BODY finishes, `while-no-input' returns whatever value BODY produced."
 (defun aggressive-indent--indent-if-changed (buffer)
   "Indent any region that changed in BUFFER in the last command loop."
   (if (not (buffer-live-p buffer))
-      (cancel-timer aggressive-indent--idle-timer)
+      (when (timerp aggressive-indent--idle-timer)
+        (cancel-timer aggressive-indent--idle-timer))
     (with-current-buffer buffer
       (when (and aggressive-indent-mode aggressive-indent--changed-list)
         (save-excursion


### PR DESCRIPTION
Fixes: Error running timer ‘aggressive-indent--indent-if-changed’: (wrong-type-argument timerp nil)