### PR TITLE
Fix #146 - Make suppress messages Emacs 28 compatible

### DIFF
--- a/aggressive-indent.el
+++ b/aggressive-indent.el
@@ -310,7 +310,8 @@ If L and R are provided, use them for finding the start and end of defun."
   "Indent current defun unobstrusively.
 Like `aggressive-indent-indent-defun', but without errors or
 messages.  L and R passed to `aggressive-indent-indent-defun'."
-  (cl-letf (((symbol-function 'message) #'ignore))
+  (let ((inhibit-message t)
+        (message-log-max nil))
     (ignore-errors (aggressive-indent-indent-defun l r))))
 
 ;;; Indenting region
@@ -382,7 +383,8 @@ then keep indenting until nothing more happens."
   "Indent region between L and R, and a bit more.
 Like `aggressive-indent-indent-region-and-on', but without errors
 or messages."
-  (cl-letf (((symbol-function 'message) #'ignore))
+  (let ((inhibit-message t)
+        (message-log-max nil))
     (ignore-errors (aggressive-indent-indent-region-and-on l r))))
 
 ;;; Tracking changes


### PR DESCRIPTION
`cl-letf`does not suppress `message` function in Emacs 28 for some reason. I suspect that `(symbol-function 'message)` returns `gnus/message.elc`. This PR fix this with another approach.

Here is one more approach that uses advice system:

```elisp
(defmacro with-suppress-messages (&rest body)
  "Suppress messages during evaluation of BODY."
  (advice-add 'message :override 'ignore)
  `(let ((return (progn ,@body)))
     (advice-remove 'message 'ignore)
     return))

(with-suppress-messages
 (ignore-errors (aggressive-indent...)))
```

but I think changing related variables temporarily like in the PR is much cleaner.