### PR TITLE
Add `exit-minibuffer` to `aggressive-indent-protected-current-commands`.

### DIFF
--- a/aggressive-indent.el
+++ b/aggressive-indent.el
@@ -138,7 +138,7 @@ commands will NOT be followed by a re-indent."
   :package-version '(aggressive-indent . "0.1"))
 
 (defcustom aggressive-indent-protected-current-commands
-  '(query-replace-regexp query-replace)
+  '(query-replace-regexp query-replace exit-minibuffer)
   "Like `aggressive-indent-protected-commands', but for the current command.
 For instance, with the default value, this variable prevents
 indentation during `query-replace' (but not after)."


### PR DESCRIPTION
This prevents indentation while running `anzu-query-replace` and
`anzu-query-replace-regexp`, for which `last-command` is `exit-minibuffer` after
reading text from the minibuffer.  See Malabarba/aggressive-indent-mode#155.